### PR TITLE
Make marking menu independent from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,25 @@
 https://vimeo.com/251253577 (a little outdated, sorry)
 
 ## Installation
-* Copy houdini_markingmenu.json in $HOUDINI_USER_PREF_DIR/packages
-* Inside the package file, change "path/to/root" to the root folder of houdini_markingmenu
+1. Copy the `python3.7libs/houdini_markingmenu` directory into
+   `$HOUDINI_USER_PREF_DIR/python3.7libs` so that Houdini can import the
+   package.  The menu now discovers its resources relative to this module and
+   no custom environment variables are required.
+2. (Optional) If you prefer using Houdini's package system, copy
+   `houdini_markingmenu.json` to `$HOUDINI_USER_PREF_DIR/packages` and edit the
+   `path/to/root` entry to point to the root folder of this repository.
+
+## Hotkey command
+The menu can be launched with the following Python snippet:
+
+```python
+import houdini_markingmenu
+houdini_markingmenu.show_menu()
 ```
-ex: "HOUDINI_MARKINGMENU": "C:\Users\myuser\Documents\houdini_markingmenu"
-```
+
+Assign this command to a hotkey inside a network editor. Holding **Ctrl** or
+**Shift** when triggering the hotkey will display the menu variant associated
+with that modifier.
 
 
 

--- a/python3.7libs/houdini_markingmenu/__init__.py
+++ b/python3.7libs/houdini_markingmenu/__init__.py
@@ -1,0 +1,23 @@
+
+"""Utility helpers for launching the marking menu."""
+
+import hou
+
+from .python import markingmenu
+
+
+def show_menu(editor=None):
+    """Display the marking menu in the given network editor.
+
+    When ``editor`` is ``None``, the network editor under the cursor is used.
+    The menu honours the current keyboard modifiers so the Control and Shift
+    variants defined in ``menu_prefs.json`` can be triggered via hotkeys.
+    """
+
+    if editor is None:
+        editor = hou.ui.paneTabUnderCursor()
+
+    if isinstance(editor, hou.NetworkEditor):
+        markingmenu.NEMarkingMenu(editor)
+    else:
+        raise hou.Error("No network editor found to display the marking menu")

--- a/python3.7libs/houdini_markingmenu/python/markingmenu.py
+++ b/python3.7libs/houdini_markingmenu/python/markingmenu.py
@@ -59,11 +59,8 @@ class NEMarkingMenu(QtWidgets.QWidget):
     def __init__(self, editor):
         super(NEMarkingMenu, self).__init__()
         
-        self.rootpath = os.path.abspath(os.path.join(
-            hou.getenv('HOUDINI_MARKINGMENU'),
-            'python3.7libs',
-            'houdini_markingmenu')
-            )
+        self.rootpath = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..'))
         
         # add python folder to path for nodegraphactivewire context
         sys.path.insert(0, os.path.join(self.rootpath, 'python'))

--- a/python3.7libs/houdini_markingmenu/python/menueditor.py
+++ b/python3.7libs/houdini_markingmenu/python/menueditor.py
@@ -38,11 +38,8 @@ class MarkingMenuEditor(QtWidgets.QWidget):
         self.setStyleSheet('background-color: rgb(58,58,58);')
         self.setFixedSize(1150 * self.dpifactor, 850 * self.dpifactor)
 
-        self._rootpath = os.path.abspath(os.path.join(
-            hou.getenv('HOUDINI_MARKINGMENU'),
-            'python3.7libs',
-            'houdini_markingmenu')
-            )
+        self._rootpath = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..'))
 
         self._contexts = sorted([
             'SOP', 'OBJ', 'DOP', 'VOP', 'ROP',


### PR DESCRIPTION
## Summary
- compute resource paths relative to the module instead of using the `HOUDINI_MARKINGMENU` env var
- document how to install without packages and show hotkey usage
- provide `show_menu()` helper to easily invoke the menu

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

